### PR TITLE
Feature/10 implement play screen

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,15 @@
 class GamesController < ApplicationController
   def play
+    @play_state = current_user.play_state
+    @event = @play_state.current_event
+    if @play_state.current_cut_position.present?
+      choice = @event.action_choices.find_by!(position: @play_state.action_choices_position)
+      @action_result = choice.action_results.find_by!(priority: @play_state.action_results_priority)
+      @cut = @action_result.cuts.find_by!(position: @play_state.current_cut_position)
+      @phase = :cut
+    else
+      @choices = @event.action_choices.order(:position)
+      @phase = :select
+    end
   end
 end

--- a/app/views/games/play.html.erb
+++ b/app/views/games/play.html.erb
@@ -2,6 +2,39 @@
   <%= link_to "ログアウト", logout_path,
       data: { turbo_method: :delete, turbo_confirm: "本当にログアウトしますか？" },
       class: "btn btn-outline-secondary mb-3" %>
+
   <h1>ゲームプレイ画面</h1>
-  <p>ここにたまごちゃんゲームのUIを実装していきます。</p>
+
+  <!-- キャラクターと背景 -->
+  <div class="position-relative my-4">
+    <%= image_tag(@cut&.character_image || @event.character_image,
+          alt: "キャラクター",
+          class: "position-absolute top-50 start-50 translate-middle") %>
+    <%= image_tag(@cut&.background_image || @event.background_image,
+          alt: "背景",
+          class: "w-100") %>
+  </div>
+
+  <!-- メッセージ表示 -->
+  <div class="message-box mb-4">
+    <%= @cut&.message || @event.message %>
+  </div>
+
+  <!-- ４つのボタン（常に表示） -->
+  <div class="d-grid gap-2 col-6 mx-auto">
+    <% 4.times do |i| %>
+      <% pos = i + 1 %>
+      <%# フェーズに応じて表示するラベルを決定 %>
+      <% if @phase == :select %>
+        <% label = @choices.find { |c| c.position == pos }&.label || "" %>
+      <% else %>
+        <% label = (pos == 1 ? "すすむ" : "") %>
+      <% end %>
+
+      <%# 全ボタンとも同じクラスを付与 %>
+      <button type="button" class="btn btn-primary" disabled>
+        <%= label %>
+      </button>
+    <% end %>
+  </div>
 </div>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,3 +8,4 @@ Rails.application.config.assets.version = "1.0"
 Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap-icons/font")
 Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap/dist/js")
 Rails.application.config.assets.precompile << "bootstrap.bundle.min.js"
+Rails.application.config.assets.paths << Rails.root.join("app/assets/images")


### PR DESCRIPTION
# feature/10-implement-play-screen：ゲームプレイ画面の表示機能を実装

## 概要
現在の `play_states` データをもとに、以下を画面上に動的に表示する機能を追加しました。  
1. キャラクターイラスト  
2. 背景イラスト  
3. ゲーム演出メッセージ  
4. 4つの行動ボタン（常に同一スタイルで無効状態）

## 変更点詳細
1. **コントローラー**  
   - `GamesController#play` にて `current_user.play_state` から  
     - `@event`（現在のイベント）  
     - `@cut` または `@choices`（カット進行 or 選択肢）  
     - `@phase`（:select／:cut）  
     を取得するロジックを追加。

2. **ビュー**  
   - `app/views/games/play.html.erb` を更新し、  
     - `<%= image_tag … %>` でキャラクター／背景を重ねて表示  
     - 独自クラス `message-box` でメッセージを表示  
     - `4.times` ループで常に4つの `<button class="btn btn-primary" disabled>` を表示  
       - 選択フェーズ：各選択肢ラベル  
       - カット進行フェーズ：1番目だけ「すすむ」、残りは空白
