### PR TITLE
すすむボタンでカットを進めるように機能追加

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -34,6 +34,31 @@ class GamesController < ApplicationController
     redirect_to root_path
   end
 
+  def advance_cut
+    play_state = current_user.play_state
+    current = play_state.current_cut_position.to_i
+    next_cut = current + 1
+    event   = play_state.current_event
+    choice  = event.action_choices.find_by!(position: play_state.action_choices_position)
+    result  = choice.action_results.find_by!(priority: play_state.action_results_priority)
+
+    if result.cuts.exists?(position: next_cut)
+      play_state.update!(current_cut_position: next_cut)
+    else
+      fixed_set   = EventSet.find_by!(name: '何かしたそう')
+      fixed_event = Event.find_by!(event_set: fixed_set, derivation_number: 0)
+
+      play_state.update!(
+        current_event_id:        fixed_event.id,
+        action_choices_position: nil,
+        action_results_priority: nil,
+        current_cut_position:    nil
+      )
+    end
+
+    redirect_to root_path
+  end
+
   private
 
   # モデル移動可

--- a/app/views/games/play.html.erb
+++ b/app/views/games/play.html.erb
@@ -22,14 +22,15 @@
       <%= @cut&.message || @event.message %>
     </div>
 
-    <%= form_with url: select_action_path, method: :post, data: { turbo_frame: "game_play" } do |f| %>
+    <%= form_with url: (@phase == :select ? select_action_path : advance_cut_path), method: :post, data: { turbo_frame: "game_play" } do |f| %>
       <div class="d-grid gap-2 col-6 mx-auto">
         <% 4.times do |i| %>
           <% pos   = i + 1 %>
           <% label = @phase == :select ?
                        (@choices.find { |c| c.position == pos }&.label) :
                        (pos == 1 ? "すすむ" : "") %>
-          <% if @phase == :select && label.present? %>
+          <% if (@phase == :select && label.present?) ||
+              (@phase == :cut    && pos == 1) %>
             <%= button_tag label,
                 type:  "submit",
                 name:  "position",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   delete "logout", to: "sessions#destroy", as: "logout"
 
   post "games/select_action", to: "games#select_action", as: "select_action"
+  post "games/advance_cut",   to: "games#advance_cut",   as: "advance_cut"
 
   root to: "games#play"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -572,6 +572,7 @@ end
 
 cuts = [
   { event_set_name: '何か言っている', derivation_number: 0, label: 'はなしをきいてあげる', priority: 1, position: 1, message: '〈たまご〉がうれしそうにはなしている！', character_image: 'character/kari-nikoniko.png', background_image: 'background/kari-background.png' },
+  { event_set_name: '何か言っている', derivation_number: 0, label: 'はなしをきいてあげる', priority: 1, position: 2, message: '〈たまご〉「んに～！！」', character_image: 'character/kari-nikoniko.png', background_image: 'background/kari-background.png' },
   { event_set_name: '何か言っている', derivation_number: 0, label: 'よしよしする',       priority: 1, position: 1, message: '〈たまご〉はよろこんでいる！', character_image: 'character/kari-nikoniko.png', background_image: 'background/kari-background.png' },
   { event_set_name: '何か言っている', derivation_number: 0, label: 'おやつをあげる',     priority: 1, position: 1, message: '〈たまご〉はよろこんでいる！', character_image: 'character/kari-nikoniko.png', background_image: 'background/kari-background.png' },
   { event_set_name: '何か言っている', derivation_number: 0, label: 'ごはんをあげる',     priority: 1, position: 1, message: '〈たまご〉はよろこんでいる！', character_image: 'character/kari-nikoniko.png', background_image: 'background/kari-background.png' },


### PR DESCRIPTION
# feature/12-implement-advance-cut-phase

## 概要
- 行動選択後フェーズで「すすむ」ボタンを押すと次のカットへ遷移する機能を実装しました。
- 最終カット到達時は、仮の固定イベントセット（‘何か言っている’）へ遷移する分岐を追加しました。

## 変更点
1. **ルーティング**  
   - `config/routes.rb`に `post "games/advance_cut", to: "games#advance_cut", as: "advance_cut"` を追加  
2. **ビュー**  
   - `app/views/games/play.html.erb`の`<form_with>`を`@phase` に応じて`select_action_path`と`advance_cut_path` に切り替え  
   - ボタンラベル／disabled制御を調整  
3. **コントローラー**  
   - `GamesController#advance_cut`を追加  
     - 次のカットがあれば`play_state.current_cut_position`をインクリメント  
     - 最終カットなら固定イベントセットに切り替え＆選択フェーズにリセット  