### PR TITLE
Feature/13 implement event set selection

### DIFF
--- a/EFFECT.md
+++ b/EFFECT.md
@@ -1,0 +1,15 @@
+# Effect JSONB スキーマ
+
+## ひな型
+
+```json
+{
+  "status": [
+    { "attribute": "hunger_value", "delta": 30 },
+    { "attribute": "love_value",   "delta": -10 }
+  ],
+  "items": [
+    { "item_code": "special_toy", "delta": 1 },
+    { "item_code": "snack",       "delta": -2 }
+  ]
+}

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -45,11 +45,12 @@ class GamesController < ApplicationController
     if result.cuts.exists?(position: next_cut)
       play_state.update!(current_cut_position: next_cut)
     else
-      fixed_set   = EventSet.find_by!(name: '何かしたそう')
-      fixed_event = Event.find_by!(event_set: fixed_set, derivation_number: 0)
+      selector   = EventSetSelector.new(current_user)
+      next_set   = selector.select_next
+      next_event = next_set.events.find_by!(derivation_number: 0)
 
       play_state.update!(
-        current_event_id:        fixed_event.id,
+        current_event_id:        next_event.id,
         action_choices_position: nil,
         action_results_priority: nil,
         current_cut_position:    nil

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -45,6 +45,8 @@ class GamesController < ApplicationController
     if result.cuts.exists?(position: next_cut)
       play_state.update!(current_cut_position: next_cut)
     else
+      apply_effects!(result.effects)
+
       selector   = EventSetSelector.new(current_user)
       next_set   = selector.select_next
       next_event = next_set.events.find_by!(derivation_number: 0)
@@ -80,5 +82,30 @@ class GamesController < ApplicationController
       end
     end
     op == "and" ? results.all? : results.any?
+  end
+
+  def apply_effects!(effects)
+    status = current_user.user_status
+
+    (effects["status"] || []).each do |e|
+      attr  = e["attribute"]
+      delta = e["delta"].to_i
+      new_value = status[attr] + delta
+      new_value = [new_value, 0].max
+      unless ["happiness_value", "money"].include?(attr)
+        new_value = [new_value, 100].min
+      end
+      new_value = [new_value, 99_999_999].min
+      status[attr] = new_value
+    end
+    status.save!
+
+    #上限値下限値要設定(大事なものについても)
+    #(effects["items"] || []).each do |e|
+      #item  = current_user.user_items.find_or_initialize_by(code: e["item_code"])
+      #delta = e["delta"].to_i
+      #item.count = item.count.to_i + delta
+      #item.save!
+    #end
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -91,21 +91,21 @@ class GamesController < ApplicationController
       attr  = e["attribute"]
       delta = e["delta"].to_i
       new_value = status[attr] + delta
-      new_value = [new_value, 0].max
-      unless ["happiness_value", "money"].include?(attr)
-        new_value = [new_value, 100].min
+      new_value = [ new_value, 0 ].max
+      unless [ "happiness_value", "money" ].include?(attr)
+        new_value = [ new_value, 100 ].min
       end
-      new_value = [new_value, 99_999_999].min
+      new_value = [ new_value, 99_999_999 ].min
       status[attr] = new_value
     end
     status.save!
 
-    #上限値下限値要設定(大事なものについても)
-    #(effects["items"] || []).each do |e|
-      #item  = current_user.user_items.find_or_initialize_by(code: e["item_code"])
-      #delta = e["delta"].to_i
-      #item.count = item.count.to_i + delta
-      #item.save!
-    #end
+    # 上限値下限値要設定(大事なものについても)
+    # (effects["items"] || []).each do |e|
+    # item  = current_user.user_items.find_or_initialize_by(code: e["item_code"])
+    # delta = e["delta"].to_i
+    # item.count = item.count.to_i + delta
+    # item.save!
+    # end
   end
 end

--- a/app/services/event_set_selector.rb
+++ b/app/services/event_set_selector.rb
@@ -1,11 +1,11 @@
 class EventSetSelector
   PRIORITY_LIST = [
-    '泣いている(空腹)',
-    '泣いている(よしよし不足)',
-    '泣いている(ランダム)',
-    '踊っている',
-    '何かしたそう',
-    '何か言っている'
+    "泣いている(空腹)",
+    "泣いている(よしよし不足)",
+    "泣いている(ランダム)",
+    "踊っている",
+    "何かしたそう",
+    "何か言っている"
   ].freeze
 
   def initialize(user)
@@ -22,35 +22,35 @@ class EventSetSelector
       return set if conditions_met?(conds)
     end
 
-    @event_sets.find { |s| s.name == '何か言っている' }
+    @event_sets.find { |s| s.name == "何か言っている" }
   end
 
   private
 
   def conditions_met?(conds)
-    return true if conds['always'] == true
+    return true if conds["always"] == true
 
-    op   = conds['operator'] || 'and'
-    list = conds['conditions'] || []
+    op   = conds["operator"] || "and"
+    list = conds["conditions"] || []
 
     results = list.map do |c|
-      case c['type']
-      when 'status'
+      case c["type"]
+      when "status"
         @status
-          .public_send(c['attribute'])
-          .public_send(c['operator'], c['value'])
-      when 'probability'
-        rand(100) < c['percent']
-      when 'item'
+          .public_send(c["attribute"])
+          .public_send(c["operator"], c["value"])
+      when "probability"
+        rand(100) < c["percent"]
+      when "item"
         @user.user_items
-             .find_by(code: c['item_code'])
+             .find_by(code: c["item_code"])
              .try(:count).to_i
-             .public_send(c['operator'], c['value'])
+             .public_send(c["operator"], c["value"])
       else
         false
       end
     end
 
-    op == 'and' ? results.all? : results.any?
+    op == "and" ? results.all? : results.any?
   end
 end

--- a/app/services/event_set_selector.rb
+++ b/app/services/event_set_selector.rb
@@ -1,0 +1,56 @@
+class EventSetSelector
+  PRIORITY_LIST = [
+    '泣いている(空腹)',
+    '泣いている(よしよし不足)',
+    '泣いている(ランダム)',
+    '踊っている',
+    '何かしたそう',
+    '何か言っている'
+  ].freeze
+
+  def initialize(user)
+    @user       = user
+    @status     = user.user_status
+    @event_sets = EventSet.all.to_a
+  end
+
+  def select_next
+    PRIORITY_LIST.each do |name|
+      set = @event_sets.find { |s| s.name == name }
+      next unless set
+      conds = set.trigger_conditions
+      return set if conditions_met?(conds)
+    end
+
+    @event_sets.find { |s| s.name == '何か言っている' }
+  end
+
+  private
+
+  def conditions_met?(conds)
+    return true if conds['always'] == true
+
+    op   = conds['operator'] || 'and'
+    list = conds['conditions'] || []
+
+    results = list.map do |c|
+      case c['type']
+      when 'status'
+        @status
+          .public_send(c['attribute'])
+          .public_send(c['operator'], c['value'])
+      when 'probability'
+        rand(100) < c['percent']
+      when 'item'
+        @user.user_items
+             .find_by(code: c['item_code'])
+             .try(:count).to_i
+             .public_send(c['operator'], c['value'])
+      else
+        false
+      end
+    end
+
+    op == 'and' ? results.all? : results.any?
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -274,7 +274,7 @@ action_results = [
     label:                 'はなしをきいてあげる',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "mood_value", "delta": 10 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -285,7 +285,8 @@ action_results = [
     label:                 'よしよしする',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "love_value", "delta": 30 } ,
+                                         { "attribute": "mood_value", "delta": 10 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -306,7 +307,8 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 30 } ,
+                                         { "attribute": "mood_value", "delta": 30 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -338,7 +340,7 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 40 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -360,7 +362,7 @@ action_results = [
     label:                 'ボールあそびをする',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "mood_value", "delta": 20 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -382,7 +384,7 @@ action_results = [
     label:                 'おえかきする',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "mood_value", "delta": 20 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -393,7 +395,7 @@ action_results = [
     label:                 'ゲームする',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "mood_value", "delta": 20 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -412,7 +414,8 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "love_value", "delta": 30 } ,
+                                         { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -423,7 +426,9 @@ action_results = [
     label:                 'よしよしする',
     priority:              2,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "love_value", "delta": 30 } , 
+                                         { "attribute": "happiness_value", "delta": 1 } ,
+                                         { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -444,7 +449,8 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 30 } ,
+                                         { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -476,7 +482,8 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 40 } ,
+                                         { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -498,7 +505,7 @@ action_results = [
     label:                 'よしよしする',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "love_value", "delta": 5 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -509,7 +516,7 @@ action_results = [
     label:                 'おやつをあげる',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 40 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -520,7 +527,7 @@ action_results = [
     label:                 'ごはんをあげる',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 50 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false
@@ -542,7 +549,7 @@ action_results = [
     label:                 'よしよしする',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               {},
+    effects:               { "status": [ { "attribute": "love_value", "delta": 30 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
     resolves_loop:         false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -39,6 +39,86 @@ event_sets.each do |attrs|
   set.save!
 end
 
+event_set_conditions = [
+  {
+    name: '泣いている(空腹)',
+    trigger_conditions: {
+      "operator":   "and",
+      "conditions": [
+        {
+          "type":      "status",
+          "attribute": "hunger_value",
+          "operator":  "<=",
+          "value":     20
+        }
+      ]
+    }
+  },
+  {
+    name: '泣いている(よしよし不足)',
+    trigger_conditions: {
+      "operator":   "and",
+      "conditions": [
+        {
+          "type":      "status",
+          "attribute": "love_value",
+          "operator":  "<=",
+          "value":     20
+        }
+      ]
+    }
+  },
+  {
+    name: '泣いている(ランダム)',
+    trigger_conditions: {
+      "operator":   "and",
+      "conditions": [
+        {
+          "type":    "probability",
+          "percent": 0
+        }
+      ]
+    }
+  },
+  {
+    name: '踊っている',
+    trigger_conditions: {
+      "operator":   "and",
+      "conditions": [
+        {
+          "type":      "status",
+          "attribute": "mood_value",
+          "operator":  ">=",
+          "value":     80
+        }
+      ]
+    }
+  },
+  {
+    name: '何かしたそう',
+    trigger_conditions: {
+      "operator":   "and",
+      "conditions": [
+        {
+          "type":    "probability",
+          "percent": 50
+        }
+      ]
+    }
+  },
+  {
+    name: '何か言っている',
+    trigger_conditions: {
+      "always": true
+    }
+  }
+]
+
+event_set_conditions.each do |attrs|
+  set = EventSet.find_by!(name: attrs[:name])
+  set.update!(trigger_conditions: attrs[:trigger_conditions])
+end
+
 events = [
   {
     event_set_name:    '何か言っている',
@@ -626,7 +706,7 @@ User.find_each do |user|
   UserStatus.find_or_create_by!(user: user) do |status|
     status.hunger_value  = 50
     status.happiness_value = 10
-    status.love_value     = 0
+    status.love_value     = 50
     status.mood_value     = 0
     status.study_value    = 0
     status.sports_value   = 0

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -285,7 +285,7 @@ action_results = [
     label:                 'よしよしする',
     priority:              1,
     trigger_conditions:    { always: true },
-    effects:               { "status": [ { "attribute": "love_value", "delta": 30 } ,
+    effects:               { "status": [ { "attribute": "love_value", "delta": 30 },
                                          { "attribute": "mood_value", "delta": 10 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
@@ -307,7 +307,7 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               { "status": [ { "attribute": "hunger_value", "delta": 30 } ,
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 30 },
                                          { "attribute": "mood_value", "delta": 30 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
@@ -414,7 +414,7 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               { "status": [ { "attribute": "love_value", "delta": 30 } ,
+    effects:               { "status": [ { "attribute": "love_value", "delta": 30 },
                                          { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
@@ -426,8 +426,8 @@ action_results = [
     label:                 'よしよしする',
     priority:              2,
     trigger_conditions:    { always: true },
-    effects:               { "status": [ { "attribute": "love_value", "delta": 30 } , 
-                                         { "attribute": "happiness_value", "delta": 1 } ,
+    effects:               { "status": [ { "attribute": "love_value", "delta": 30 },
+                                         { "attribute": "happiness_value", "delta": 1 },
                                          { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
@@ -449,7 +449,7 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               { "status": [ { "attribute": "hunger_value", "delta": 30 } ,
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 30 },
                                          { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,
@@ -482,7 +482,7 @@ action_results = [
                                 }
                               ]
                             },
-    effects:               { "status": [ { "attribute": "hunger_value", "delta": 40 } ,
+    effects:               { "status": [ { "attribute": "hunger_value", "delta": 40 },
                                          { "attribute": "mood_value", "delta": -100 } ] },
     next_derivation_number: nil,
     calls_event_set_name:  nil,


### PR DESCRIPTION
## 概要
- 最終カット到達時に固定セットではなく、ユーザーのステータスや確率などの条件をもとに次のイベントセットを選出する機能を実装しました。

## 変更点
1. **サービスオブジェクトの追加**  
   - `app/services/event_set_selector.rb` を新規作成  
   - `PRIORITY_LIST` によるイベントセットの優先順位を定義し、`trigger_conditions`（JSONB）を評価して次セットを返却  

2. **コントローラー修正**  
   - `GamesController#advance_cut` 内の最終カットの場合の処理を以下のように変更：  
     - `EventSetSelector.new(current_user).select_next` を呼び出して`Play_state`を更新
  

3. **Seed データ修正**  
   - `db/seeds.rb` の `event_sets` 定義直後に、JSONB 形式の `trigger_conditions` を優先順位順に上書きするスクリプトを追加  
   - 各セットの条件例：  
     ```ruby
     {
       name: '泣いている(空腹)',
       trigger_conditions: {
         "operator":   "and",
         "conditions": [
           { "type": "status", "attribute": "hunger_value", "operator": "<=", "value": 20 }
         ]
       }
     }
     ```
   - 最後の `'何か言っている'` は `{ "always": true }` のみ  

4. **Action_Resultによるステータス変動実装**  
   - 最終カットのすすむボタン押した際ステータス変動が行われるよう実装
   - ステータス変動内容をSeedデータに追加、変動処理が行われるよう`GamesController#advance_cut`を修正