### PR TITLE
コンソールに表示されるpreloadに関する警告が消えるよう対処

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,6 @@ module App
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     config.i18n.available_locales = [ :ja, :en ]
+    config.action_view.preload_links_header = false
   end
 end


### PR DESCRIPTION
## 概要
Railsの自動Asset Preload用Link ヘッダー送信機能を無効化し、開発者ツールに表示されていた  `preload but not used` 警告を解消しました。

## 変更内容
- `config/environments/production.rb` に`config.action_view.preload_links_header = false`を追加。