### PR TITLE
オートログイン実装（LINEログイン用）

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -6,6 +6,11 @@ class OauthsController < ApplicationController
   #   login_at(auth_params[:provider])
   # end
 
+  def line_login
+    session[:remember] = params[:remember]
+    redirect_to '/auth/line'
+  end
+
   def callback
     auth_hash = request.env["omniauth.auth"]
     Rails.logger.debug "=== AUTH HASH ===\n#{auth_hash.to_h.inspect}\n================="
@@ -36,6 +41,7 @@ class OauthsController < ApplicationController
       Authentication.create!(user: user, provider: auth_hash.provider, uid: auth_hash.uid)
       user
     end
+    remember_flag = session.delete(:remember)
     reset_session
     session[:user_id] = @user.id
     session[:pending_oauth] = {
@@ -47,6 +53,7 @@ class OauthsController < ApplicationController
 
     if @user.profile_completed?
       auto_login(@user)
+      remember_me! if remember_flag == '1'
       redirect_to root_path, success: "ログインに成功しました。"
     else
       redirect_to complete_profile_path

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container mt-5" style="max-width: 400px;">
   <h1 class="mb-4">ログイン</h1>
 
-  <%= form_with url: login_path, local: true, html: { class: 'needs-validation' } do |f| %>
+  <%= form_with url: login_path, local: true, html: { id: 'login-form', class: 'needs-validation' } do |f| %>
     <div class="mb-3">
       <%= f.label :email, 'メールアドレス', class: 'form-label' %>
       <%= f.email_field :email, name: :email, class: 'form-control', required: true, placeholder: 'example@example.com' %>
@@ -24,7 +24,17 @@
   <% end %>
 
   <div class="d-grid mb-3">
-    <%= link_to 'LINEでログイン', '/auth/line', class: 'btn btn-primary mb-3' %>
+    <button
+      type="submit"
+      form="login-form"
+      formaction="<%= line_login_path %>"
+      formmethod="get"
+      formnovalidate
+      data-turbo="false"
+      class="btn btn-primary mb-3"
+    >
+      LINEでログイン
+    </button>
   </div>
 
   <div class="text-center">

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -12,7 +12,7 @@ Rails.application.config.sorcery.configure do |config|
   config.line.key          = ENV["LINE_KEY"]
   config.line.secret       = ENV["LINE_SECRET"]
   if Rails.env.development?
-    config.line.callback_url = "https://401c-133-106-185-55.ngrok-free.app/auth/line/callback"
+    config.line.callback_url = "https://847d-210-157-210-200.ngrok-free.app/auth/line/callback"
   elsif Rails.env.production?
     config.line.callback_url = "https://www.tamago-wakuwaku.com/auth/line/callback"
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   patch "/password_resets/update", to: "password_resets#update", as: "update_password_reset"
   get "/password_resets/complete_update", to: "password_resets#complete_update", as: "complete_update_password_reset"
 
+  get '/line_login', to: 'oauths#line_login', as: 'line_login'
   match "/auth/:provider/callback", to: "oauths#callback", via: %i[get post]
   get "/auth/failure",            to: redirect("/")
 


### PR DESCRIPTION
# Pull Request: LINEログイン時のオートログイン対応
## 概要
- LINEでログインボタンで「次回から自動でログインするチェック」の情報を送信できるようにフォーム周りを修正。
- LINEでログインボタンではHTML5バリデーション無効化（`formnovalidate`）し、Email等未入力でもフォーム送信できるように。
- 「LINEでログイン」リンクを `<button>` に置き換えたらページ遷移しなくなったので、該当ボタンにおいてTurbo無効化（`data-turbo="false"`）を追加
- callbackアクションで`remember_me!`を呼び出し。
- `params[:remember]`が`/auth/line`で保持できないようだったので`params[:remember]`をセッションに保存する処理は中継アクションで処理。
  - LINEログイン前の中継用ルート `GET /line_login` を追加し、`OauthsController#line_login` に紐付け
  - `OauthsController#line_login`アクションで`params[:remember]` をセッションに保存してから`/auth/line`へリダイレクト  
  - 「LINEでログイン」ボタンの`formaction` を中継ルート（`line_login_path`）に設定 
- `OauthsController#callback`アクションを修正  
    - セッションリセット前に保存フラグを変数に退避、退避フラグに応じて`remember_me!`を呼び出し  
 