### PR TITLE
Feature/47 timeout event transition

### DIFF
--- a/app/models/play_state.rb
+++ b/app/models/play_state.rb
@@ -5,4 +5,10 @@ class PlayState < ApplicationRecord
   validates :action_choices_position, numericality: { only_integer: true }, allow_nil: true
   validates :action_results_priority, numericality: { only_integer: true }, allow_nil: true
   validates :current_cut_position,    numericality: { only_integer: true }, allow_nil: true
+
+  TIMEOUT = 2.hours
+
+  def event_timeout?
+    updated_at < TIMEOUT.ago
+  end
 end

--- a/app/models/play_state.rb
+++ b/app/models/play_state.rb
@@ -1,6 +1,7 @@
 class PlayState < ApplicationRecord
-  belongs_to :user
-  belongs_to :current_event,   class_name: "Event"
+  belongs_to  :user
+  belongs_to  :current_event,   class_name: "Event"
+  delegate    :user_status, to: :user
 
   validates :action_choices_position, numericality: { only_integer: true }, allow_nil: true
   validates :action_results_priority, numericality: { only_integer: true }, allow_nil: true
@@ -10,5 +11,19 @@ class PlayState < ApplicationRecord
 
   def event_timeout?
     updated_at < TIMEOUT.ago
+  end
+
+  def start_new_event!(next_event)
+    update!(
+      current_event_id:        next_event.id,
+      action_choices_position: nil,
+      action_results_priority: nil,
+      current_cut_position:    nil
+    )
+  end
+
+  def apply_automatic_update!
+    user_status.apply_automatic_update!(updated_at)
+    touch
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,6 +45,16 @@ class User < ApplicationRecord
     [ next_set, next_event ]
   end
 
+  def reset_event_temporary_data!
+    event_temporary_datum.update!(
+      reception_count: 0,
+      success_count: 0,
+      started_at: nil,
+      special_condition: nil,
+      ended_at: nil,
+    )
+  end
+
   private
   def assign_friend_code
     loop do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,17 @@ class User < ApplicationRecord
     egg_name != "未登録"
   end
 
+  def clear_event_category_invalidations!
+    user_event_category_invalidations.where("expires_at < ?", Time.current).delete_all
+  end
+
+  def pick_next_event_set_and_event
+    selector = EventSetSelector.new(self)
+    next_set = selector.select_next
+    next_event = next_set.events.find_by!(derivation_number: 0)
+    [ next_set, next_event ]
+  end
+
   private
   def assign_friend_code
     loop do

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -15,7 +15,7 @@ class UserStatus < ApplicationRecord
             :science,         :science_effort,
             :social_studies,  :social_effort,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
-            
+
   def clear_loop_status!
     update!(
       current_loop_event_set_id: nil,

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -1,6 +1,10 @@
 class UserStatus < ApplicationRecord
-  belongs_to :user
-  belongs_to :current_loop_event_set, class_name: "EventSet", optional: true
+  belongs_to  :user
+  belongs_to  :current_loop_event_set, class_name: "EventSet", optional: true
+  delegate    :play_state,              to: :user
+  delegate    :current_event,           to: :play_state
+  delegate    :event_set,               to: :current_event
+  delegate    :event_category,          to: :event_set
 
   validates :hunger_value,    :happiness_value,
             :love_value,      :mood_value,
@@ -11,4 +15,48 @@ class UserStatus < ApplicationRecord
             :science,         :science_effort,
             :social_studies,  :social_effort,
             numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+            
+  def clear_loop_status!
+    update!(
+      current_loop_event_set_id: nil,
+      current_loop_started_at:   nil
+    )
+  end
+
+  def in_loop?
+    return false unless current_loop_event_set_id == event_set.id
+    current_loop_started_at > event_category.loop_minutes.minutes.ago
+  end
+
+  def loop_timeout?
+    current_loop_event_set_id.present? && !in_loop?
+  end
+
+  def apply_automatic_update!(play_state_updated_at)
+    now       = Time.current
+    elapsed   = now - play_state_updated_at
+
+    hunger_ticks = (elapsed / 15.minutes).floor
+    self.hunger_value -= hunger_ticks if hunger_ticks > 0
+
+    love_ticks = (elapsed / 8.hours).floor
+    self.love_value -= love_ticks * 25 if love_ticks > 0
+
+    vitality_ticks = (elapsed / 5.minutes).floor
+    self.temp_vitality += vitality_ticks * 10 if vitality_ticks > 0
+
+    self.hunger_value  = [ [ self.hunger_value, 0 ].max, 100 ].min
+    self.love_value    = [ [ self.love_value,   0 ].max, 100 ].min
+    self.temp_vitality = [ self.temp_vitality, self.vitality ].min
+
+    save!
+  end
+
+  def record_loop_start!
+    return if event_category.loop_minutes.blank?
+    update!(
+      current_loop_event_set_id: event_set.id,
+      current_loop_started_at: Time.current
+    )
+  end
 end

--- a/app/services/event_timeout.rb
+++ b/app/services/event_timeout.rb
@@ -1,0 +1,38 @@
+class EventTimeout
+  def initialize(play_state, user_status, headers)
+    @user        = user_status.user
+    @play_state  = play_state
+    @user_status = user_status
+    @headers     = headers
+  end
+
+  def handle_timeouts
+    return if turbo_request?
+    return unless timeout?
+    execute_timeout_flow
+  end
+
+  private
+
+  def turbo_request?
+    @headers["Turbo-Visit"].present? || @headers["Turbo-Frame"].present?
+  end
+
+  def timeout?
+    current_set = @play_state.current_event.event_set
+    @user_status.loop_timeout? || normal_event_timeout?
+  end
+
+  def normal_event_timeout?
+    @user_status.current_loop_event_set_id.blank? && @play_state.event_timeout?
+  end
+
+  def execute_timeout_flow
+    @play_state.apply_automatic_update!
+    @user.clear_event_category_invalidations!
+    @user_status.clear_loop_status!
+    next_set, next_event = @user.pick_next_event_set_and_event
+    @user_status.record_loop_start!
+    @play_state.start_new_event!(next_event)
+  end
+end

--- a/app/services/event_timeout.rb
+++ b/app/services/event_timeout.rb
@@ -30,6 +30,7 @@ class EventTimeout
   def execute_timeout_flow
     @play_state.apply_automatic_update!
     @user.clear_event_category_invalidations!
+    @user.reset_event_temporary_data!
     @user_status.clear_loop_status!
     next_set, next_event = @user.pick_next_event_set_and_event
     @user_status.record_loop_start!


### PR DESCRIPTION
# 非ループイベントのタイムアウト処理実装
ループ時間切れループイベントのタイムアウト処理は実装済みでしたが、非ループイベントもタイムアウトするようにしました。  
これにより、例えば「夜中にゲームプレイ画面開いたら、本来たまごちゃんが寝てるはずなのに前回のイベントの状態が残ってる」というようなことがなくなります。

## 概要
- 非ループイベントを対象に、最終プレイから2時間以上経った場合、再アクセス時にイベント終了時の次イベントセット選定処理を走らせ強制的に次のイベントへ遷移させます。
- ループ解除処理やステータス更新などの付随する処理はループイベントのタイムアウト処理同様、そのため既存のタイムアウト処理の条件範囲を拡張した形に。
- 特訓イベントで使用するevent_temporary_dataのデータをリセットする処理を追加。
- 今回の機能実装に合わせ、ループイベントのタイムアウト処理周りのコードのみリファクタリング。モデルのインスタンスメソッドに移せるものは移し、残りの処理はサービスクラスへ。