### PR TITLE
ステータス画面のステータスラベル部分表示幅修正

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -182,7 +182,7 @@ input.form-control[readonly] {
 
 .status-list .status-label {
   display: inline-block;
-  width: 5.5em;
+  width: 7.5em;
   margin-right: 0.5em;
   margin-left: 0.5em;
 }


### PR DESCRIPTION
# ステータス画面のステータスラベル部分表示幅修正
自身のスマホ画面で表示した際、ラベルの一部が改行されていたため、ラベル部分の幅を広くしました。

## 備考
- DevToolsではスマホ画面程度の幅にしても改行されていなかったため、詳しい原因は不明。今回の修正で改善され無い場合は要調査。