### PR TITLE
Feature/48 self account delete

### DIFF
--- a/app/controllers/delete_account_controller.rb
+++ b/app/controllers/delete_account_controller.rb
@@ -1,0 +1,12 @@
+class DeleteAccountController < ApplicationController
+  skip_after_action :register_last_activity_time_to_db, only: :destroy
+
+  def show
+  end
+
+  def destroy
+    current_user.destroy!
+    reset_session
+    redirect_to login_path, danger: "アカウントを削除しました。", status: :see_other
+  end
+end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -95,8 +95,7 @@ class GamesController < ApplicationController
           user_status.clear_loop_status!
           next_set, next_event = current_user.pick_next_event_set_and_event
           next_set, next_event = apply_event_set_call(result, next_set, next_event)
-          next_set, next_event = apply_event_set_call(result, next_set, next_event)
-          user_status.record_loop_start!
+          user_status.record_loop_start!(next_set)
         end
       end
 

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -52,10 +52,10 @@ class UserStatus < ApplicationRecord
     save!
   end
 
-  def record_loop_start!
-    return if event_category.loop_minutes.blank?
+  def record_loop_start!(next_set)
+    return if next_set.event_category.loop_minutes.blank?
     update!(
-      current_loop_event_set_id: event_set.id,
+      current_loop_event_set_id: next_set.id,
       current_loop_started_at: Time.current
     )
   end

--- a/app/services/event_timeout.rb
+++ b/app/services/event_timeout.rb
@@ -33,7 +33,7 @@ class EventTimeout
     @user.reset_event_temporary_data!
     @user_status.clear_loop_status!
     next_set, next_event = @user.pick_next_event_set_and_event
-    @user_status.record_loop_start!
+    @user_status.record_loop_start!(next_set)
     @play_state.start_new_event!(next_event)
   end
 end

--- a/app/views/delete_account/show.html.erb
+++ b/app/views/delete_account/show.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, 'アカウント削除' %>
+
+<section class="privacy-policy container my-5 mx-0 mx-md-auto" style="max-width: 1200px;>
+  <div class="text-start mb-3">
+    <%= link_to 'もどる', (settings_path), class: 'btn btn-outline-secondary mb-3' %>
+  </div>
+
+  <div class="text-center">
+    <h3 class="mb-4">アカウント削除</h3>
+
+    <p>
+      アカウント削除を行うページです。誤って削除すると戻すことはできませんので十分ご注意ください。
+    </p>
+    <%= link_to "アカウントを削除する", delete_account_path,
+          data: { turbo_method: :delete, turbo_confirm: "アカウントの復旧はできません。本当に削除しますか？" },
+          class: "btn btn-danger" %>
+  </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
   </head>
 
   <body>
-    <% unless controller_name.in?(%w[games privacy_policies term settings line_notification_settings status]) %>
+    <% unless controller_name.in?(%w[games privacy_policies term settings line_notification_settings status delete_account]) %>
       <%= render 'shared/flash_message' %>
     <% end %>
     <%= yield %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -18,7 +18,7 @@
       <% end %>
     </li>
     <li>
-      アカウント削除
+      <%= link_to "アカウント削除", delete_account_path, class: "text-decoration-underline" %>
     </li>
   </ul>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   get   "/settings", to: "settings#show", as: :settings
   get   "/settings/line_notification", to: "line_notification_settings#show", as: :settings_line_notification
   patch "/settings/line_notification", to: "line_notification_settings#update"
+  get   "/settings/delete_account", to: "delete_account#show", as: :delete_account
+  delete "/settings/delete_account", to: "delete_account#destroy"
 
   post "/webhooks/line", to: "line_webhooks#callback"
 

--- a/spec/requests/delete_account_spec.rb
+++ b/spec/requests/delete_account_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "DeleteAccounts", type: :request do
+  describe "GET /show" do
+    xit "returns http success" do
+      get "/delete_account/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    xit "returns http success" do
+      get "/delete_account/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/delete_account/show.html.erb_spec.rb
+++ b/spec/views/delete_account/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "delete_account/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# アカウント削除機能実装
アカウント削除機能を追加しました。

## 概要
- .設定一覧画面からアカウント削除ページへ移れるように。
- アカウント削除ボタンを押すと、アカウント削除を行い、ログインページへ遷移。

## 備考
- 今回の本来の実装とは関係ないが既存の機能のバグ（ループ処理が正しく行われない）があったので修正。
- アカウント削除ボタンを押した際エラーが発生。Sorceryのactivity_loggingサブモジュールが提供するregister_last_activity_time_to_dbメソッドがアカウント削除後に動いていたため、`skip_after_action :register_last_activity_time_to_db, only: :destroy`を追加し対応。