### PR TITLE
Fix/51 fix event set call

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -94,8 +94,7 @@ class GamesController < ApplicationController
           next_event = event
         else
           user_status.clear_loop_status!
-          next_set, next_event = current_user.pick_next_event_set_and_event
-          next_set, next_event = apply_event_set_call(result, next_set, next_event)
+          next_set, next_event = pick_event_with_set_call_or_default(result)
           user_status.record_loop_start!(next_set)
         end
       end
@@ -176,14 +175,14 @@ class GamesController < ApplicationController
     inv.save!
   end
 
-  def apply_event_set_call(action_result, default_set, default_event)
+  def pick_event_with_set_call_or_default(action_result)
     if action_result.calls_event_set_id.present?
       event_set = EventSet.find(action_result.calls_event_set_id)
       event = event_set.events.find_by!(derivation_number: 0)
-      [ event_set, event ]
     else
-      [ default_set, default_event ]
+      event_set, event = current_user.pick_next_event_set_and_event
     end
+    [ event_set, event ]
   end
 
   def apply_derivation(result)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3093,7 +3093,7 @@ action_results = [
     event_set_name: 'イントロ', derivation_number: 7, label: 'よしよし', priority: 1,
     trigger_conditions:    { always: true },
     effects: {},
-    next_derivation_number: nil, calls_event_set_name: '何か言っている', resolves_loop: false
+    next_derivation_number: nil, calls_event_set_name: nil, resolves_loop: false
   },
   {
     event_set_name: '誕生日', derivation_number: 0, label: 'すすむ', priority: 1, trigger_conditions: { always: true },


### PR DESCRIPTION
# イベントセットコールの不具合修正
イベントセットコール時に、呼び出されていないイベントセットがその日呼び出されたとしてカウントされてしまう不具合を修正しました。

## バグの発覚
  - 前回ブランチで「誕生日イベント」を作成した。しかし実装後バグが見つかる。
    - 事象：誕生日を今日とした新規作成ユーザーがゲーム開始直後、誕生日イベントが発生することを期待したが発生しなかった。
    - 原因：ゲーム開始直後はイントロダクションイベントから、イベントセットコールで「何か言っている」イベントに遷移するが、イベントセットコール前に誕生日イベントがEventSetSelectorで選定されており、その日に1回発生した扱いに、その後選定イベントがイベントセットコールで上書きされたため、その日は誕生日イベントが発生しなくなってしまった。
      ```
      next_set, next_event = current_user.pick_next_event_set_and_event
      next_set, next_event = apply_event_set_call(result, next_set, next_event) # 上書きする形になっていた。
      ```
## 修正内容
- `app/controllers/games_controller.rb`
    - `apply_event_set_call`メソッドを`pick_event_with_set_call_or_default`という名前のメソッドに修正
    - 通常のイベントセット選定処理である`current_user.pick_next_event_set_and_event`を`pick_event_with_set_call_or_default`メソッド内へ移動、その中でイベントセットコールと分岐処理をさせ、従来の上書き処理を廃止。
- `db/seeds.rb`
  - イントロダクションイベントのイベントセットコール廃止。
    - この修正をしなくとも、ゲーム開始直後に誕生日イベントが正しく発生しバグが治ったことは確認済み。
    - たまごちゃんが寝ていないとおかしい時間に、ゲーム開始直後「寝ている」系統のイベントに遷移しないということが起こってしまわないようにするため修正した。