### PR TITLE
イベントの時間帯による発生条件を、日にちによってだけじゃなくユーザーによっても変わるように修正

### DIFF
--- a/app/services/condition_evaluator.rb
+++ b/app/services/condition_evaluator.rb
@@ -18,7 +18,7 @@ class ConditionEvaluator
       when "status"       then status_judge?(c)
       when "probability"  then probability_judge?(c)
       when "item"         then item_judge?(c)
-      when "time_range"   then TimeRangeChecker.new(c, now: @now).time_range_met?
+      when "time_range"   then TimeRangeChecker.new(@user, c, now: @now).time_range_met?
       when "weekday"      then weekday_judge?(c)
       when "date_range"   then date_range_judge?(c)
       else false

--- a/app/services/time_range_checker.rb
+++ b/app/services/time_range_checker.rb
@@ -1,5 +1,6 @@
 class TimeRangeChecker
-  def initialize(condition_hash, now: Time.current)
+  def initialize(user, condition_hash, now: Time.current)
+    @user_id    = user.id
     @condition  = condition_hash
     @now        = now
     @day        = now.to_date.day
@@ -32,7 +33,7 @@ class TimeRangeChecker
   end
 
   def apply_offset_by_day(ob, from, to)
-    delta = ((@day + ob["add"].to_i) * ob["mult"].to_i) % ob["mod"].to_i
+    delta = ((@day + @user_id + ob["add"].to_i) * ob["mult"].to_i) % ob["mod"].to_i
 
     case ob["target"]
     when "to_min"


### PR DESCRIPTION
# イベントセットの時間帯による発生条件を、日にちによってだけじゃなくユーザーによっても変わるように修正
TimeRangeCheckerサービスクラスのapply_offset_by_dayメソッドで、イベントセットの発生時間を日にちによって変わるようにしていましたが、user_idにも依存するように修正しました。

## 目的
友達同士等、複数のユーザー同士で比較したときに、「たまごちゃん」が同じ行動パターンになってしまわないように配慮し機能修正。