### PR TITLE
新規ユーザー登録リンクの警告ダイアログからページ遷移しない不具合修正

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -47,7 +47,7 @@
       <div class="text-center">
         <%= link_to '新規登録はこちら',
             signup_path,
-            data: { turbo_method: :delete, turbo_confirm: "LINEログインを利用しない場合、LINEメッセージを利用した機能がご利用できません。\nよろしいでしょうか。" },
+            onclick: "return confirm('LINEログインを利用しない場合、LINEメッセージを利用した機能がご利用できません。\\nよろしいでしょうか。')",
             class: 'btn btn-link'%>
       </div>
       <div class="text-center mb-2">


### PR DESCRIPTION
# 新規ユーザー登録リンクの警告ダイアログからページ遷移しない不具合修正

## 概要
- 新規登録ユーザーリンクで`turbo_method: :delete`を指定していた（コードを他の箇所から流用したため）ため、ページ遷移ではなくDELETEリクエストが送信される状態になっていた。
- とりあえず`turbo_method`を削除したところ`turbo_confirm`が機能せず、警告ダイアログが表示されなくなった（Rails7以降では GETリンクにturbo_confirmが効かない模様）。
- このため、`turbo_method: :delete`を削除し、`onclick`にJavaScriptの`confirm()`を直接記述することで、GET遷移でも警告ダイアログを表示できるように修正した。

## 動作確認
- リンククリック時に確認ダイアログが表示されることを確認
- OK押下時に新規登録ページへ遷移
- キャンセル押下時はページ遷移せずにとどまる