### PR TITLE
一部のイベントセットの発生確率調整

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -132,19 +132,19 @@ event_set_conditions = [
   },
   {
     name: 'ボーっとしている',
-    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 30 } ] }
+    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 10 } ] }
   },
   {
     name: 'ニコニコしている',
-    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 42 } ] }
+    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 22 } ] }
   },
   {
     name: 'ゴロゴロしている',
-    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 37 } ] }
+    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 28 } ] }
   },
   {
     name: '何かしたそう',
-    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 50 } ] }
+    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 40 } ] }
   },
   {
     name: '何か言っている',


### PR DESCRIPTION
# 一部のイベントセットの発生確率調整

## 概要
- 発生条件が確率によるもののみのイベントセット（カテゴリ：通常、暇そう）の発生確率を調整
- 今まではカテゴリ「暇そう」の発生確率と「通常」の発生確率の割合がおよそ75:25だったが50:50程度になるよう調整
  - 「暇そう」は行動選択肢が一つのみだけで、割合が高いとゲームテンポが悪くなる。75:25だとかなりテンポが悪かったため50:50に調整