### PR TITLE
Feature/74 modification view

### DIFF
--- a/app/views/line_notification_settings/show.html.erb
+++ b/app/views/line_notification_settings/show.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, 'LINE通知設定' %>
+<% content_for :title, 'LINEメッセージ機能' %>
 
 <section class="privacy-policy container my-5 mx-0 mx-md-auto" style="max-width: 1200px;>
   <div class="text-start mb-3">
     <%= link_to 'もどる', (settings_path), class: 'btn btn-outline-secondary mb-3' %>
   </div>
 
-  <h3 class="mb-4">LINE通知設定</h3>
+  <h3 class="mb-4">LINEメッセージ機能</h3>
 
   <li class="mb-2">
     LINEメッセージ機能を利用するにはLINEともだち追加が必要になります。

--- a/app/views/line_notification_settings/show.html.erb
+++ b/app/views/line_notification_settings/show.html.erb
@@ -8,7 +8,7 @@
   <h3 class="mb-4">LINE通知設定</h3>
 
   <li class="mb-2">
-    LINE通知機能を利用するにはLINEともだち追加が必要になります。
+    LINEメッセージ機能を利用するにはLINEともだち追加が必要になります。
   </li>
 
   <div class="d-flex align-items-center mb-3">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -10,10 +10,10 @@
   <ul>
     <li>
       <% if current_user && current_user.authentications.exists?(provider: "line") %>
-        <%= link_to "LINE通知", settings_line_notification_path, class: "text-decoration-underline" %>
+        <%= link_to "LINEメッセージ機能", settings_line_notification_path, class: "text-decoration-underline" %>
       <% else %>
         <span class="text-muted">
-          LINE通知（LINEログインユーザーのみ利用可能）
+          LINEメッセージ機能（LINEログインユーザーのみ利用可能）
         </span>
       <% end %>
     </li>

--- a/app/views/users/complete_profile.html.erb
+++ b/app/views/users/complete_profile.html.erb
@@ -9,7 +9,7 @@
       <%= image_tag( "main/complete_profile.png", alt: "パスワードリセット", class: "img-fluid mb-4" ) %>
     </div>
     <div class="col-12 col-md-3">
-      <h1 class="mb-4">ユーザー情報登録</h1>
+      <h1 class="mb-4">プロフィール登録</h1>
 
       <%= render 'shared/error_messages', object: @user %>
 
@@ -20,8 +20,8 @@
         </div>
 
         <div class="mb-3">
-          <%= f.label :egg_name, 'たまごちゃん名（6文字以内）', class: 'form-label' %>
-          <%= f.text_field :egg_name, class: 'form-control', maxlength: 6, required: true %>
+          <%= f.label :egg_name, 'たまごの名前（6文字以内）', class: 'form-label' %>
+          <%= f.text_field :egg_name, value: '', class: 'form-control', maxlength: 6, required: true %>
         </div>
 
         <div class="row mb-3">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -35,7 +35,7 @@
         </div>
 
         <div class="mb-3">
-          <%= f.label :egg_name, 'たまごちゃん名（6文字以内）', class: 'form-label' %>
+          <%= f.label :egg_name, 'たまごの名前（6文字以内）', class: 'form-label' %>
           <%= f.text_field :egg_name, class: 'form-control', maxlength: 6, required: true %>
         </div>
 


### PR DESCRIPTION
# viewの一部の内容を修正

## 概要
- `app/views/line_notification_settings/show.html.erb`
  - 「LINE通知設定」という文言を「LINEメッセージ機能」に差し替え（Webhookを用いたメッセージ自動返信機能などもあるため）
- `app/views/settings/show.html.erb`
  - 同上
- `app/views/users/complete_profile.html.erb`
  - 「たまごちゃん名」という文言を「たまごの名前」に差し替え
  - 「たまごの名前」フォームのデフォルト表示を空欄に
    - もともとは、初回LINEログインによって自動作成される仮データで設定される「未登録」という名前が自動表示されていたが、それを非表示に。
- `app/views/users/new.html.erb`
  -  「たまごちゃん名」という文言を「たまごの名前」に差し替え