### PR TITLE
ご飯やおやつをあげられるhunger_value上限値を変更

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1579,7 +1579,7 @@ action_results = [
                                   "type": "status",
                                   "attribute": "hunger_value",
                                   "operator": "<=",
-                                  "value": 90
+                                  "value": 95
                                 }
                               ]
                             },
@@ -1612,7 +1612,7 @@ action_results = [
                                   "type": "status",
                                   "attribute": "hunger_value",
                                   "operator": "<=",
-                                  "value": 70
+                                  "value": 85
                                 }
                               ]
                             },
@@ -1976,7 +1976,7 @@ action_results = [
                                   "type": "status",
                                   "attribute": "hunger_value",
                                   "operator": "<=",
-                                  "value": 90
+                                  "value": 95
                                 }
                               ]
                             },
@@ -2009,7 +2009,7 @@ action_results = [
                                   "type": "status",
                                   "attribute": "hunger_value",
                                   "operator": "<=",
-                                  "value": 70
+                                  "value": 85
                                 }
                               ]
                             },
@@ -2759,7 +2759,7 @@ action_results = [
   },
   {
     event_set_name: '扇風機', derivation_number: 0, label: 'スイカをあげる', priority: 1,
-    trigger_conditions:    { "operator": "and", "conditions": [ { "type": "status", "attribute": "hunger_value", "operator": "<=", "value": 90 } ] },
+    trigger_conditions:    { "operator": "and", "conditions": [ { "type": "status", "attribute": "hunger_value", "operator": "<=", "value": 95 } ] },
     effects: { "status": [ { "attribute": "hunger_value", "delta": 30 }, { "attribute": "vitality", "delta": 3 } ] },
     next_derivation_number: nil, calls_event_set_name: nil, resolves_loop: false
   },
@@ -2789,7 +2789,7 @@ action_results = [
   },
   {
     event_set_name: 'こたつ', derivation_number: 0, label: 'ミカンをあげる', priority: 1,
-    trigger_conditions:    { "operator": "and", "conditions": [ { "type": "status", "attribute": "hunger_value", "operator": "<=", "value": 90 } ] },
+    trigger_conditions:    { "operator": "and", "conditions": [ { "type": "status", "attribute": "hunger_value", "operator": "<=", "value": 95 } ] },
     effects: { "status": [ { "attribute": "hunger_value", "delta": 30 }, { "attribute": "vitality", "delta": 1 } ] },
     next_derivation_number: nil, calls_event_set_name: nil, resolves_loop: false
   },


### PR DESCRIPTION
# ご飯やおやつをあげられるhunger_value上限値を変更

## 調整した背景
- 既存の設定値の場合、ごはんをあげられるのはhunger_valueが70以下の場合。
- hunger_valueが最高値の場合100だが、ごはんをあげられる70まで自動減少（15分につき1）するのに7時間30分かかり、お腹がすくのに時間がかかるように感じられる。
- 以上を踏まえ、ごはんをあげる、おやつをあげる、どちらもあげることができるhunger_value上限値を再調整。