### PR TITLE
イベントセット発生確率調整

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -132,15 +132,15 @@ event_set_conditions = [
   },
   {
     name: 'ボーっとしている',
-    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 5 } ] }
+    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 15 } ] }
   },
   {
     name: 'ニコニコしている',
-    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 6 } ] }
+    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 9 } ] }
   },
   {
     name: 'ゴロゴロしている',
-    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 10 } ] }
+    trigger_conditions: { "operator":   "and", "conditions": [ { "type":    "probability", "percent": 9 } ] }
   },
   {
     name: '何かしたそう',


### PR DESCRIPTION
# イベントセット発生確率調整

## 概要
- 過去のブランチで「ボーっとしている」イベントでなつき具合を確認できるようにしたので、「ボーっとしている」イベントの発生確率を上げる方向で再調整