### PR TITLE
ログイン画面のmainバナーが上からすっと出現するように

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -219,3 +219,20 @@ body.fade-in::before {
 body.fade-in.show::before {
   opacity: 0;
 }
+
+@keyframes slideDownFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.login-banner {
+  opacity: 0;
+  animation: slideDownFadeIn 1s ease-out forwards;
+  animation-delay: 0.6s;
+}


### PR DESCRIPTION
# ログイン画面のmainバナーが上からすっと出現するように

## 概要
- ログイン画面全体のフェードインよりワンテンポ遅れて、mainバナーが上から降りてくるようにフェードイン。
- css(`app/assets/stylesheets/_custom.scss`)追加のみの修正。