### PR TITLE
Fix/86 fix login view

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -201,7 +201,8 @@ body.fade-in::before {
   inset: 0;
   background: #ffffff;
   opacity: 1;
-  transition: opacity 1s ease-in;
+  transition: opacity 1.0s ease-in;
+  transition-delay: 0.5s;
   pointer-events: none;
   z-index: 9999;
 }
@@ -223,8 +224,8 @@ body.fade-in.show::before {
 
 .login-banner {
   opacity: 0;
-  animation: slideDownFadeIn 1s ease-out forwards;
-  animation-delay: 0.6s;
+  animation: slideDownFadeIn 2.0s ease-out forwards;
+  animation-delay: 1.2s;
 }
 
 @media (max-width: 767px) {

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,5 +1,4 @@
 <% content_for :head do %>
-  <meta name="turbo-visit-control" content="reload">
   <%= preload_link_tag asset_path("main/login.png"), as: "image", type: "image/png" %>
 <% end %>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,5 @@
 <% content_for :head do %>
+  <meta name="turbo-visit-control" content="reload">
   <%= preload_link_tag asset_path("main/login.png"), as: "image", type: "image/png" %>
 <% end %>
 
@@ -7,7 +8,11 @@
 <div class="container mt-0 mt-md-5">
   <div class="row gx-4 justify-content-center align-items-md-center">
     <div class="col-12 mt-4 mt-md-0 col-md-6 mb-0 mb-md-3 me-md-5 mt-md-4">
-      <%= image_tag( "main/login.png", alt: "ログインバナー", class: "img-fluid mb-4 login-banner" ) %>
+      <%= image_tag "main/login.png",
+        alt: "ログインバナー",
+        class: "img-fluid mb-4 login-banner",
+        width: 1114, height: 707,
+        loading: "eager", decoding: "async", fetchpriority: "high" %>
     </div>
 
     <div class="col-12 col-md-3 mt-md-3">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,3 +1,7 @@
+<% content_for :head do %>
+  <%= preload_link_tag asset_path("main/login.png"), as: "image", type: "image/png" %>
+<% end %>
+
 <% content_for :title, 'ログイン' %>
 
 <div class="container mt-0 mt-md-5">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -51,7 +51,7 @@
         </div>
 
         <div class="d-grid">
-          <%= f.submit '登録する', class: 'btn btn-alt btn-lg' %>
+          <%= f.submit '登録する', class: 'btn btn-alt btn-lg', data: { turbo: false } %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
# ログイン画面の修正

## 概要
- デプロイしたアプリをスマートフォンで操作していた際、以下の二つの不具合があったため修正をした。
  - メインバナーの下方向移動アニメーション動作中に、読み込み中画像（画像の上半分だけ見えてるようなイメージ）のままアニメーション動作に入ってしまっていた。
    - 対応：preload等で画像の読み込み速度を速くした
    - 備考：JSで読み込み完了を待つ処理を加えるのが確実だが、とりあえず、今回のような簡単な対応で様子見。
  - 新規ユーザー登録時、ログイン画面に移った際、画面の下の方にスクロールされた状態で表示される不具合があった。
    - 対応：ユーザー登録時のボタンに`data: { turbo: false }`を追加。
    - 備考1：Rails7や8ではフォーム送信がデフォルトでtrubo drive適用となっている。
    - 備考2：ログインビューで` <meta name="turbo-visit-control" content="reload">`を追加し、必ずフルリロード
  させることも検討したが、フラッシュメッセージが消えてしまうので不採用とした。