### PR TITLE
Refactor/94 refactor gams controller

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,5 +1,4 @@
 class GamesController < ApplicationController
-
   def play
     # apply_automatic_update!によるステータス更新が適切に行われなくなるため@play_state.touchはしない
     # @play_state.apply_automatic_update!はしない
@@ -35,7 +34,7 @@ class GamesController < ApplicationController
     result   = play_state.current_action_result
 
     return handle_next_cut(play_state, next_cut_position) if result.cuts.exists?(position: next_cut_position)
-    return handle_next_event(play_state, result)
+    handle_next_event(play_state, result)
   end
 
   private

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -66,7 +66,8 @@ class GamesController < ApplicationController
       end
     end
 
-    next_set, next_event = call_training_event_processor(result, next_set, next_event)
+    training_next_set, training_next_event = call_training_event_processor(result)
+    next_set, next_event = training_next_set, training_next_event if training_next_event.present?
 
     play_state.start_new_event!(next_event)
 
@@ -164,14 +165,17 @@ class GamesController < ApplicationController
     end
   end
 
-  def call_training_event_processor(result, next_set, next_event)
-    arithmetic_training_event_processor = ArithmeticTrainingEventProcessor.new(current_user, result, next_set, next_event)
-    next_set, next_event = arithmetic_training_event_processor.call
+  def call_training_event_processor(result)
+    arithmetic_training_event_processor = ArithmeticTrainingEventProcessor.new(current_user, result)
+    a_next_set, a_next_event = arithmetic_training_event_processor.call
     arithmetic_training_event_processor.record_evaluation
 
-    ball_training_event_processor = BallTrainingEventProcessor.new(current_user, result, next_set, next_event)
-    next_set, next_event = ball_training_event_processor.call
+    ball_training_event_processor = BallTrainingEventProcessor.new(current_user, result)
+    b_next_set, b_next_event = ball_training_event_processor.call
     ball_training_event_processor.record_evaluation
-    [ next_set, next_event ]
+
+    return [ a_next_set, a_next_event ] if a_next_event.present?
+    return [ b_next_set, b_next_event ] if b_next_event.present?
+    return [ nil, nil ]
   end
 end

--- a/app/models/action_choice.rb
+++ b/app/models/action_choice.rb
@@ -4,4 +4,31 @@ class ActionChoice < ApplicationRecord
 
   validates :position, presence: true, inclusion: { in: 1..4 }
   validates :label,    presence: true
+
+  def selected_result(user)
+    result   = action_results.order(:priority).detect { |ar| conditions_met?(ar.trigger_conditions, user) }
+    result ||= action_results.order(:priority).first
+  end
+
+  private
+  def conditions_met?(conds, user)
+    return true if conds["always"] == true
+    op   = conds["operator"] || "and"
+    list = conds["conditions"] || []
+    results = list.map do |c|
+      case c["type"]
+      when "status"
+        user.user_status.public_send(c["attribute"]).public_send(c["operator"], c["value"])
+      when "probability"
+        rand(100) < c["percent"]
+      when "item"
+        user.user_items.find_by(code: c["item_code"]).try(:count).to_i.public_send(c["operator"], c["value"])
+      when "event_temporary_data"
+        user.event_temporary_datum.public_send(c["attribute"]).public_send(c["operator"], c["value"])
+      else
+        false
+      end
+    end
+    op == "and" ? results.all? : results.any?
+  end
 end

--- a/app/models/action_result.rb
+++ b/app/models/action_result.rb
@@ -8,6 +8,17 @@ class ActionResult < ApplicationRecord
   validates :trigger_conditions, presence: true
   validate  :exclusive_derivation_or_call
 
+  def apply_derivation
+    event_set = action_choice.event.event_set
+    begin
+      derived_event = event_set.events.find_by!(derivation_number: next_derivation_number)
+    rescue ActiveRecord::RecordNotFound
+      Rails.logger.warn "Derivation event not found: set=#{event_set.id}, num=#{next_derivation_number}"
+      derived_event = event_set.events.find_by!(derivation_number: 0)
+    end
+    [ event_set, derived_event ]
+  end
+
   private
 
   def exclusive_derivation_or_call

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,4 +5,12 @@ class Event < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :event_set_id }
   validates :derivation_number, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :message, :character_image, :background_image, presence: true
+
+  def ordered_action_choices
+    action_choices.order(:position)
+  end
+
+  def arithmetic_quiz_being_asked?
+    event_set.name == "算数" && (1..4).include?(derivation_number)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,4 +13,8 @@ class Event < ApplicationRecord
   def arithmetic_quiz_being_asked?
     event_set.name == "算数" && (1..4).include?(derivation_number)
   end
+
+  def selected_choice(position)
+    action_choices.find_by!(position: position)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,6 +82,12 @@ class User < ApplicationRecord
     end
   end
 
+  def invalidate_event_category!(event_category, expires_at)
+    inv = user_event_category_invalidations.find_or_initialize_by(event_category: event_category)
+    inv.expires_at = expires_at
+    inv.save!
+  end
+
   private
   def assign_friend_code
     loop do

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -53,6 +53,21 @@ class UserStatus < ApplicationRecord
     save!
   end
 
+  def apply_effects!(effects)
+    (effects["status"] || []).each do |e|
+      attr  = e["attribute"]
+      delta = e["delta"].to_i
+      new_value = self[attr] + delta
+      new_value = [ new_value, 0 ].max
+      if [ "hunger_value", "love_value", "mood_value" ].include?(attr)
+        new_value = [ new_value, 100 ].min
+      end
+      new_value = [ new_value, 99_999_999 ].min
+      self[attr] = new_value
+    end
+    save!
+  end
+
   def record_loop_start!(next_set)
     return if next_set.event_category.loop_minutes.blank?
     update!(

--- a/app/presenters/game_view_presenter.rb
+++ b/app/presenters/game_view_presenter.rb
@@ -1,0 +1,73 @@
+class GameViewPresenter
+  attr_reader :play_state, :event
+
+  def initialize(play_state)
+    @play_state = play_state
+    @event      = play_state.current_event
+  end
+
+  def phase
+    after_select_phase? ? :after_select : :select_now
+  end
+
+  # choice、action_result、cutメソッドの3つはafter_select_phase用
+  def choice
+    return unless after_select_phase?
+    play_state.current_choice
+  end
+
+  def action_result
+    return unless after_select_phase?
+    play_state.current_action_result
+  end
+
+  def cut
+    return unless after_select_phase?
+    play_state.current_cut
+  end
+
+  # choices、arithmetic_question_text、arithmetic_optionsメソッドの3つはselect_now_phase用
+  def choices
+    return unless select_now_phase?
+    event.ordered_action_choices
+  end
+
+  def arithmetic_question_text
+    arithmetic_payload&.first
+  end
+
+  def arithmetic_options
+    arithmetic_payload&.last
+  end
+
+  # いずれのphaseでも使用
+  def base_background_image
+    case Time.current.hour
+    when 6...17
+      "temp-base_background/temp-base_background1.png"
+    when 17...18
+      "temp-base_background/temp-base_background2.png"
+    else
+      "temp-base_background/temp-base_background3.png"
+    end
+  end
+
+  private
+
+  def after_select_phase?
+    play_state.current_cut_position.present?
+  end
+
+  def select_now_phase?
+    !after_select_phase?
+  end
+
+  def arithmetic_payload
+    return unless select_now_phase? && event.arithmetic_quiz_being_asked?
+    @arithmetic_payload ||= ArithmeticQuiz.generate(seed: seed)
+  end
+
+  def seed
+    play_state.updated_at.to_i
+  end
+end

--- a/app/services/arithmetic_training_event_processor.rb
+++ b/app/services/arithmetic_training_event_processor.rb
@@ -1,12 +1,10 @@
 class ArithmeticTrainingEventProcessor
   MAX_RECEPTIONS = 20
 
-  def initialize(user, result, next_set, next_event)
+  def initialize(user, result)
     @user       = user
     @status     = user.user_status
     @result     = result
-    @next_set   = next_set
-    @next_event = next_event
     @temp       = user.event_temporary_datum
   end
 
@@ -16,7 +14,8 @@ class ArithmeticTrainingEventProcessor
     return continue_process if continue_process?
     return evaluation if evaluation?
 
-    [ @next_set, @next_event ]
+    # event_setもeventも返さない
+    [ nil, nil ]
   end
 
   def record_evaluation

--- a/app/services/ball_training_event_processor.rb
+++ b/app/services/ball_training_event_processor.rb
@@ -1,12 +1,10 @@
 class BallTrainingEventProcessor
   MAX_ALLOWED_MISTAKES = 3
 
-  def initialize(user, result, next_set, next_event)
+  def initialize(user, result)
     @user       = user
     @status     = user.user_status
     @result     = result
-    @next_set   = next_set
-    @next_event = next_event
     @temp       = user.event_temporary_datum
   end
 
@@ -21,7 +19,8 @@ class BallTrainingEventProcessor
     end
     return evaluation if evaluation?
 
-    [ @next_set, @next_event ]
+    # event_setもeventも返さない
+    [ nil, nil ]
   end
 
   def record_evaluation

--- a/app/services/decide_next_event.rb
+++ b/app/services/decide_next_event.rb
@@ -1,0 +1,63 @@
+class DecideNextEvent
+  def initialize(user)
+    @user         = user
+    @user_status  = user.user_status
+    @event        = user.play_state.current_event
+    @current_set  = @event.event_set
+    @result       = user.play_state.current_action_result
+    @resolves     = @result.resolves_loop?
+  end
+
+  def call
+    if @result.next_derivation_number.present?
+      next_set, next_event = @result.apply_derivation
+    else
+      if @resolves
+        @user.invalidate_event_category!(@current_set.event_category, 2.hours.from_now)
+      end
+      if continue_loop?
+        next_set = @current_set
+        next_event = @event
+      else
+        @user_status.clear_loop_status!
+        next_set, next_event = pick_event_with_set_call_or_default
+        @user_status.record_loop_start!(next_set)
+      end
+    end
+
+    training_next_set, training_next_event = call_training_event_processor
+    next_set, next_event = training_next_set, training_next_event if training_next_event.present?
+
+    [ next_set, next_event ]
+  end
+
+  private
+  def continue_loop?
+    return false if @resolves
+    @user_status.in_loop?
+  end
+
+  def pick_event_with_set_call_or_default
+    if @result.calls_event_set_id.present?
+      event_set = EventSet.find(@result.calls_event_set_id)
+      event = event_set.events.find_by!(derivation_number: 0)
+    else
+      event_set, event = @user.pick_next_event_set_and_event
+    end
+    [ event_set, event ]
+  end
+
+  def call_training_event_processor
+    arithmetic_training_event_processor = ArithmeticTrainingEventProcessor.new(@user, @result)
+    a_next_set, a_next_event = arithmetic_training_event_processor.call
+    arithmetic_training_event_processor.record_evaluation
+
+    ball_training_event_processor = BallTrainingEventProcessor.new(@user, @result)
+    b_next_set, b_next_event = ball_training_event_processor.call
+    ball_training_event_processor.record_evaluation
+
+    return [ a_next_set, a_next_event ] if a_next_event.present?
+    return [ b_next_set, b_next_event ] if b_next_event.present?
+    return [ nil, nil ]
+  end
+end

--- a/app/services/decide_next_event.rb
+++ b/app/services/decide_next_event.rb
@@ -59,6 +59,6 @@ class DecideNextEvent
 
     return [ a_next_set, a_next_event ] if a_next_event.present?
     return [ b_next_set, b_next_event ] if b_next_event.present?
-    return [ nil, nil ]
+    [ nil, nil ]
   end
 end

--- a/app/services/decide_next_event.rb
+++ b/app/services/decide_next_event.rb
@@ -32,6 +32,7 @@ class DecideNextEvent
   end
 
   private
+
   def continue_loop?
     return false if @resolves
     @user_status.in_loop?

--- a/app/services/event_set_selector.rb
+++ b/app/services/event_set_selector.rb
@@ -75,9 +75,17 @@ class EventSetSelector
 
   def record_occurrence(set)
     return if set.daily_limit.nil?
+    return if record_occurrence_skip?
     rec = DailyLimitEventSetCount.find_or_initialize_by(user: @user, event_set: set, occurred_on: Date.current)
     rec.count += 1
     rec.save!
+  end
+
+  def record_occurrence_skip?
+    result = @user.play_state.current_action_result
+    return false if result.action_choice.event.event_set.name == "特訓" && [ 2, 3, 4, 5, 6 ].include?(result.action_choice.event.derivation_number)
+
+    ["算数特訓", "ボール遊び特訓"].include?(@user.event_temporary_datum.special_condition)
   end
 
   def filter_invalid_categories!

--- a/app/services/event_set_selector.rb
+++ b/app/services/event_set_selector.rb
@@ -57,16 +57,13 @@ class EventSetSelector
   end
 
   def filter_daily_limits!
+    counts_by_set = DailyLimitEventSetCount.where(user: @user, occurred_on: Date.current).pluck(:event_set_id, :count).to_h
+
     @event_sets.reject! do |set|
       limit = set.daily_limit
       next false if limit.nil?
-      today_count(set) >= limit
+      (counts_by_set[set.id] || 0) >= limit
     end
-  end
-
-  def today_count(set)
-    rec = DailyLimitEventSetCount.find_by(user: @user, event_set: set, occurred_on: Date.current)
-    rec&.count.to_i
   end
 
   def event_triggerable?(set)
@@ -83,6 +80,7 @@ class EventSetSelector
 
   def record_occurrence_skip?
     result = @user.play_state.current_action_result
+    return false if result.nil?
     return false if result.action_choice.event.event_set.name == "特訓" && [ 2, 3, 4, 5, 6 ].include?(result.action_choice.event.derivation_number)
 
     ["算数特訓", "ボール遊び特訓"].include?(@user.event_temporary_datum.special_condition)

--- a/app/services/event_set_selector.rb
+++ b/app/services/event_set_selector.rb
@@ -83,7 +83,7 @@ class EventSetSelector
     return false if result.nil?
     return false if result.action_choice.event.event_set.name == "特訓" && [ 2, 3, 4, 5, 6 ].include?(result.action_choice.event.derivation_number)
 
-    ["算数特訓", "ボール遊び特訓"].include?(@user.event_temporary_datum.special_condition)
+    [ "算数特訓", "ボール遊び特訓" ].include?(@user.event_temporary_datum.special_condition)
   end
 
   def filter_invalid_categories!

--- a/app/views/games/play.html.erb
+++ b/app/views/games/play.html.erb
@@ -20,19 +20,19 @@
       <div class="col-12 col-md-8">
         <div class="position-relative my-2 mx-auto play-image-wrapper">
           <%= image_tag(
-                effective_image_path(@base_background_image),
+                effective_image_path(@presenter.base_background_image),
                 alt: "ベース背景",
                 class: "position-absolute top-0 start-0 img-fluid w-100",
                 style: "z-index: -1;"
               ) %>
           <%= image_tag(
-                effective_image_path(@cut&.background_image || @event.background_image),
+                effective_image_path(@presenter.cut&.background_image || @presenter.event.background_image),
                 alt: "背景",
                 class: "img-fluid",
                 style: "z-index: 0;"
               ) %>
           <%= image_tag(
-                effective_image_path(@cut&.character_image || @event.character_image),
+                effective_image_path(@presenter.cut&.character_image || @presenter.event.character_image),
                 alt: "キャラクター",
                 class: "position-absolute top-50 start-50 translate-middle img-fluid",
                 style: "width: 80%; z-index: 1;"
@@ -42,19 +42,19 @@
 
       <div class="col-12 col-md-4 pe-md-6 d-grid gap-1 mt-2 mt-md-4">
         <div class="message-box mb-1 py-4 d-flex align-items-center justify-content-center">
-          <% message = MessageBuilder.new(@play_state, @question_text).call %>
+          <% message = MessageBuilder.new(@presenter.play_state, @presenter.arithmetic_question_text).call %>
           <%= message.html_safe %>
         </div>
-        <%= form_with url: (@phase == :select ? select_action_path : advance_cut_path), method: :post, data: { turbo_frame: "game_play" } do |f| %>
-          <%= hidden_field_tag :state_timestamp, @play_state.updated_at.iso8601 %>
+        <%= form_with url: (@presenter.phase == :select_now ? select_action_path : advance_cut_path), method: :post, data: { turbo_frame: "game_play" } do |f| %>
+          <%= hidden_field_tag :state_timestamp, @presenter.play_state.updated_at.iso8601 %>
           <div class="d-grid gap-2 mx-auto mt-2 mt-md-4" style="width: 80%;">
             <% 4.times do |i| %>
               <% pos   = i + 1 %>
               <% label =
-                if @phase == :select
-                  orig = (@choices.find { |c| c.position == pos }&.label || "").dup
-                  if @question_text.present?
-                    @options.each_with_index do |opt, idx|
+                if @presenter.phase == :select_now
+                  orig = (@presenter.choices.find { |c| c.position == pos }&.label || "").dup
+                  if @presenter.arithmetic_question_text.present?
+                    @presenter.arithmetic_options.each_with_index do |opt, idx|
                       placeholder = "〈#{('A'.ord + idx).chr}〉"
                       orig.gsub!(placeholder, opt.to_s)
                     end
@@ -65,8 +65,8 @@
                   pos == 1 ? "つぎへ" : ""
                 end %>
 
-              <% if (@phase == :select && label.present?) ||
-                  (@phase == :cut    && pos == 1) %>
+              <% if (@presenter.phase == :select_now && label.present?) ||
+                  (@presenter.phase == :after_select    && pos == 1) %>
                 <%= button_tag label,
                     type:  "submit",
                     name:  "position",


### PR DESCRIPTION
# gams_controllerのリファクタリング

## リファクタリング概要
- 可読性向上、責務分離が主な目的
- 各モデルや新規作成したDecideNextEventサービスクラスに責務を譲渡

## リファクタリング中に発見した不具合の修正
- EventSetSelectorのrecord_occurrenceをskipする条件を追加
  - トレーニングイベント中、意図せずrecord_occurrenceが処理される不具合があった。
  - この不具合は、トレーニングイベントの特殊な次イベント選定が、通常の次イベント選定を上書きしていることから起因していて、そのような場合はrecord_occurrence処理をスキップするよう修正した。
  - そもそも通常の次イベント選定を上書きする処理を廃止し、条件分岐させることが望ましいが、条件がやや複雑なためこのような修正に留めた。
- N + 1問題解消