### PR TITLE
ボタンのhoverのcssをPCのみ適用に

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -87,9 +87,11 @@ footer {
 }
 
 // btn-1がグレーボタン、btn-2が薄オレンジ色ボタン
-.btn-1:hover {
-  background-color: lighten(#f2f2f2, 10%) !important;
-  color: #222222 !important;
+@media (hover: hover) and (pointer: fine) {
+  .btn-1:hover {
+    background-color: lighten(#f2f2f2, 10%) !important;
+    color: #222222 !important;
+  }
 }
 
 .btn-1.btn-large-text {
@@ -106,8 +108,10 @@ footer {
   color: #222222 !important;
 }
 
-.btn-2:hover {
-  background-color: lighten($btn-2-bg, 10%) !important;
+@media (hover: hover) and (pointer: fine) {
+  .btn-2:hover {
+    background-color: lighten($btn-2-bg, 10%) !important;
+  }
 }
 
 .btn-link {


### PR DESCRIPTION
# ボタンのhoverのcssをPCのみ適用に

## 概要
- 以前CSSの修正で、ゲームプレイ画面の行動選択ボタンに対してもhover時のCSS（色が変わる）を適用するようにしたが、スマホで使うとボタンを押した直後に色が変わってターボによるページ更新が始まりテンポ遅くなったように感じた。
- この不具合を修正するためにhover時のCSSはPCのみ反映されるように修正。