### PR TITLE
算数特訓のタイムがメッセージで正しく表示されない不具合修正

### DIFF
--- a/app/helpers/message_builder.rb
+++ b/app/helpers/message_builder.rb
@@ -36,7 +36,7 @@ class MessageBuilder
     message = message.gsub("〈X〉", success_count.to_s)
     elapsed_sec = (temp.ended_at - temp.started_at).to_i
     minutes, seconds = elapsed_sec.divmod(60)
-    time_str    = "#{minutes}ふん#{seconds}びょう"
-    message     = message.gsub("〈Y〉分〈Z〉秒", time_str)
+    time_str    = "#{minutes}ふん #{seconds}びょう"
+    message     = message.gsub("〈Y〉ふん 〈Z〉びょう", time_str)
   end
 end


### PR DESCRIPTION
# 算数特訓のタイムがメッセージで正しく表示されない不具合修正

## 概要
- タイム結果は特定のメッセージ文言を置換して表示する仕組みだが、置換検索対象となる文言をseedデータで謝って修正したいたため、正しく表示されなくなっていた。
- 置換検索対象を修正。