### PR TITLE
初回LINE認証時のプルフィール保管ページのレイアウト調整

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -143,6 +143,12 @@ footer {
 }
 
 @media (min-width: 768px) {
+  .mt-md-6 {
+    margin-top: 6rem !important;
+  }
+}
+
+@media (min-width: 768px) {
   .vertical-spacing-lg {
     margin-top: 13rem !important;
     margin-bottom: 13rem !important;

--- a/app/views/users/complete_profile.html.erb
+++ b/app/views/users/complete_profile.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'ユーザー登録' %>
 
-<div class="container mt-5" >
+<div class="container mt-5 mt-md-6" >
   <div class="row gx-4 justify-content-center align-items-md-center">
     <div class="col-12 col-md-6 mb-0 me-md-5">
       <%= image_tag( "main/complete_profile.png", alt: "パスワードリセット", class: "img-fluid mb-4" ) %>


### PR DESCRIPTION
# 初回LINE認証時のプルフィール保管ページのレイアウト調整

##概要
- ページ上部の余白を追加。
- 以前このページの最上部に配置していた「もどる」ボタンを削除したことによりページ全体が上方向にずれた。
- 当ページは下に余白があるため、上寄りの配置になってしまったため、「もどる」ボタンがあった時と同じくらいの配置になるよう上部の余白を追加。