### PR TITLE
DBの設定変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ development:
   <<: *default
   host: db
   port: 5432
-  database: hikaru_dev
+  database: hikaru
   username: hikaru
   password: hikaru_pass
 


### PR DESCRIPTION
# DBの設定変更

## 概要
- 今までRspec実行時にコマンドでDATABASE_URLを指定していた。
- このようにしないと開発環境DBを使用するようになっていて、原因が分からずにいた。

## 原因
- database.ymlで管理していたつもりが.envでDATABASE_URLを指定していたため、database.ymlの内容を無視して開発/テスト環境ともに同じDBを使用するようになっていた（Rspec実行時にコマンドでDATABASE_URLを指定しない場合）。

## 修正内容
- .envのDATABASE_URLを削除
- database.ymlの開発環境のDB接続先を正しく修正