### PR TITLE
Rspecテストコード修正

### DIFF
--- a/spec/models/action_choice_spec.rb
+++ b/spec/models/action_choice_spec.rb
@@ -75,99 +75,22 @@ RSpec.describe ActionChoice, type: :model do
     let(:user)   { double('User') }
 
     it 'selected_resultメソッドは条件を満たすaction_resultを返す' do
-      allow(choice).to receive(:conditions_met?).and_return(false, true)
+      false_eval = instance_double(ConditionEvaluator, conditions_met?: false)
+      true_eval  = instance_double(ConditionEvaluator, conditions_met?: true)
+
+      allow(ConditionEvaluator).to receive(:new).and_return(false_eval, true_eval)
       result1 = create(:action_result, action_choice: choice, priority: 1)
       result2 = create(:action_result, action_choice: choice, priority: 2)
       expect(choice.selected_result(user)).to eq(result2)
     end
 
     it 'selected_resultメソッドは条件を満たすaction_resultがなければ最初のaction_resultを返す' do
-      allow(choice).to receive(:conditions_met?).and_return(false, false)
+      false_eval = instance_double(ConditionEvaluator, conditions_met?: false)
+
+      allow(ConditionEvaluator).to receive(:new).and_return(false_eval, false_eval)
       result1 = create(:action_result, action_choice: choice, priority: 1)
       result2 = create(:action_result, action_choice: choice, priority: 2)
       expect(choice.selected_result(user)).to eq(result1)
-    end
-  end
-
-  describe 'プライベートメソッド#conditions_met?' do
-    context '複数条件のand/or判定' do
-      let(:true_condition)  { { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 10 } }
-      let(:false_condition) { { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 100 } }
-
-      it 'and: 真真→true' do
-        conds = { "operator" => "and", "conditions" => [ true_condition, true_condition ] }
-        expect(choice.send(:conditions_met?, conds, user)).to eq true
-      end
-      it 'and: 真偽→false' do
-        conds = { "operator" => "and", "conditions" => [ true_condition, false_condition ] }
-        expect(choice.send(:conditions_met?, conds, user)).to eq false
-      end
-      it 'and: 偽偽→false' do
-        conds = { "operator" => "and", "conditions" => [ false_condition, false_condition ] }
-        expect(choice.send(:conditions_met?, conds, user)).to eq false
-      end
-      it 'or: 真真→true' do
-        conds = { "operator" => "or", "conditions" => [ true_condition, true_condition ] }
-        expect(choice.send(:conditions_met?, conds, user)).to eq true
-      end
-      it 'or: 真偽→true' do
-        conds = { "operator" => "or", "conditions" => [ true_condition, false_condition ] }
-        expect(choice.send(:conditions_met?, conds, user)).to eq true
-      end
-      it 'or: 偽偽→false' do
-        conds = { "operator" => "or", "conditions" => [ false_condition, false_condition ] }
-        expect(choice.send(:conditions_met?, conds, user)).to eq false
-      end
-    end
-
-  let(:choice) { ActionChoice.new }
-  let(:user) { double(user_status: double(hungry_value: 50)) }
-
-    it 'alwaysがtrueなら必ずtrue' do
-      conds = { "always" => true }
-      expect(choice.send(:conditions_met?, conds, user)).to eq true
-    end
-
-    it 'status条件（１つのみ）がtrueならtrue' do
-      conds = {
-        "operator" => "and",
-        "conditions" => [
-          { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 10 }
-        ]
-      }
-      expect(choice.send(:conditions_met?, conds, user)).to eq true
-    end
-
-    it 'status条件（１つのみ）がtrueならfalse' do
-      conds = {
-        "operator" => "and",
-        "conditions" => [
-          { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 90 }
-        ]
-      }
-      expect(choice.send(:conditions_met?, conds, user)).to eq false
-    end
-
-    it 'probability条件（１つのみ）がtrueになる場合' do
-      conds = {
-        "operator" => "and",
-        "conditions" => [
-          { "type" => "probability", "percent" => 100 }
-        ]
-      }
-      allow_any_instance_of(Object).to receive(:rand).and_return(99)
-      expect(choice.send(:conditions_met?, conds, user)).to eq true
-    end
-
-    it 'probability条件（１つのみ）がfalseになる場合' do
-      conds = {
-        "operator" => "and",
-        "conditions" => [
-          { "type" => "probability", "percent" => 0 }
-        ]
-      }
-      allow_any_instance_of(Object).to receive(:rand).and_return(0)
-      expect(choice.send(:conditions_met?, conds, user)).to eq false
     end
   end
 end

--- a/spec/services/condition_evaluator_spec.rb
+++ b/spec/services/condition_evaluator_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe ConditionEvaluator do
+  let(:user) { double(user_status: double(hungry_value: 50)) }
+
+  describe '#conditions_met?' do
+    context '複数条件のand/or判定' do
+      let(:true_condition)  { { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 10 } }
+      let(:false_condition) { { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 100 } }
+
+      it 'and: 真真→true' do
+        conds = { "operator" => "and", "conditions" => [ true_condition, true_condition ] }
+        evaluator = described_class.new(user, conds)
+        expect(evaluator.conditions_met?).to eq true
+      end
+      it 'and: 真偽→false' do
+        conds = { "operator" => "and", "conditions" => [ true_condition, false_condition ] }
+        evaluator = described_class.new(user, conds)
+        expect(evaluator.conditions_met?).to eq false
+      end
+      it 'and: 偽偽→false' do
+        conds = { "operator" => "and", "conditions" => [ false_condition, false_condition ] }
+        evaluator = described_class.new(user, conds)
+        expect(evaluator.conditions_met?).to eq false
+      end
+      it 'or: 真真→true' do
+        conds = { "operator" => "or", "conditions" => [ true_condition, true_condition ] }
+        evaluator = described_class.new(user, conds)
+        expect(evaluator.conditions_met?).to eq true
+      end
+      it 'or: 真偽→true' do
+        conds = { "operator" => "or", "conditions" => [ true_condition, false_condition ] }
+        evaluator = described_class.new(user, conds)
+        expect(evaluator.conditions_met?).to eq true
+      end
+      it 'or: 偽偽→false' do
+        conds = { "operator" => "or", "conditions" => [ false_condition, false_condition ] }
+        evaluator = described_class.new(user, conds)
+        expect(evaluator.conditions_met?).to eq false
+      end
+    end
+
+    it 'alwaysがtrueなら必ずtrue' do
+      conds = { "always" => true }
+      evaluator = described_class.new(user, conds)
+      expect(evaluator.conditions_met?).to eq true
+    end
+
+    it 'status条件（１つのみ）がtrueならtrue' do
+      conds = {
+        "operator" => "and",
+        "conditions" => [
+          { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 10 }
+        ]
+      }
+      evaluator = described_class.new(user, conds)
+      expect(evaluator.conditions_met?).to eq true
+    end
+
+    it 'status条件（１つのみ）がfalseならfalse' do
+      conds = {
+        "operator" => "and",
+        "conditions" => [
+          { "type" => "status", "attribute" => "hungry_value", "operator" => ">", "value" => 90 }
+        ]
+      }
+      evaluator = described_class.new(user, conds)
+      expect(evaluator.conditions_met?).to eq false
+    end
+
+    it 'probability条件（１つのみ）がtrueになる場合' do
+      conds = {
+        "operator" => "and",
+        "conditions" => [
+          { "type" => "probability", "percent" => 100 }
+        ]
+      }
+      evaluator = described_class.new(user, conds)
+      allow(evaluator).to receive(:rand).and_return(99)
+      expect(evaluator.conditions_met?).to eq true
+    end
+
+    it 'probability条件（１つのみ）がfalseになる場合' do
+      conds = {
+        "operator" => "and",
+        "conditions" => [
+          { "type" => "probability", "percent" => 0 }
+        ]
+      }
+      evaluator = described_class.new(user, conds)
+      allow(evaluator).to receive(:rand).and_return(0)
+      expect(evaluator.conditions_met?).to eq false
+    end
+  end
+end

--- a/spec/support/authentication_macros.rb
+++ b/spec/support/authentication_macros.rb
@@ -1,9 +1,16 @@
 module AuthenticationMacros
   def login(user, password = 'password')
+    Capybara.reset_sessions!
     visit new_session_path
+    expect(page).to have_selector('form', wait: 5)
+    expect(page).to have_field(I18n.t('activerecord.attributes.user.email'),    disabled: :all, wait: 5)
+    expect(page).to have_field(I18n.t('activerecord.attributes.user.password'), disabled: :all, wait: 5)
+    expect(page).to have_field(I18n.t('activerecord.attributes.user.email'),    disabled: false, wait: 5)
+    expect(page).to have_field(I18n.t('activerecord.attributes.user.password'), disabled: false, wait: 5)
     fill_in I18n.t('activerecord.attributes.user.email'),    with: user.email
     fill_in I18n.t('activerecord.attributes.user.password'), with: password
     click_button I18n.t('buttons.login')
+    expect(page).to have_current_path(root_path, ignore_query: true, wait: 5)
   end
 
   def sign_up_as(attrs)


### PR DESCRIPTION
# Rspecテストコード修正

## 主な変更内容
- 以前ActionChoiceモデルのconditions_met?メソッドの処理をConditionEvaluatorサービスクラスのconditions_met?メソッドに置き換えたことに合わせてのテストコード修正
  - spec/services/condition_evaluator_spec.rb新規作成
  - spec/models/action_choice_spec.rb修正
    - 一部のテストを削除（spec/services/condition_evaluator_spec.rbに移したため）
    - 一部のコードを修正（conditions_met?呼び出し関連）
- spec/support/authentication_macros.rb修正
  - 以上の修正後なぜか他のテストでログインが正しくできない（ログインフォームが見つからない）不具合が発生したため修正